### PR TITLE
weapon level correct when game reset

### DIFF
--- a/game.js
+++ b/game.js
@@ -342,12 +342,13 @@ function create(game) {
     maxhp: 5,
     hasEffect: false,
     weapon: {
-      name: weaponList[currentWeapon],
+      name: weaponList[0],
       damageMin: 1,
       damageMax: 3,
     },
   };
   currentLvl = 1;
+  currentWeapon = 0;
   init();
 
   renderText();


### PR DESCRIPTION
Previously when a player clicked the reset button the game would restart, but their weapon level and weapon.name would stay the same. Now the weapon object and weaponLevel should now be reset properly when a new game is created. 

To test: 

- Start playing a game until you get a weapon other than stick

- Restart the game and ensure that the text reads that your weapon is a stick