### PR TITLE
Bugfix/restart keeps enemy hp message

### DIFF
--- a/game.js
+++ b/game.js
@@ -349,6 +349,7 @@ function create(game) {
   };
   currentLvl = 1;
   currentWeapon = 0;
+  currentEnemy = undefined;
   init();
 
   renderText();
@@ -360,7 +361,7 @@ function restart() {
     rng = new Math.seedrandom(`${seedInput.value}1`);
     rngGen = new Math.seedrandom(`${seedInput.value}2`);
   }
-  create();
+  create(game);
   gameRun = true;
 }
 

--- a/game.js
+++ b/game.js
@@ -360,7 +360,7 @@ function restart() {
     rng = new Math.seedrandom(`${seedInput.value}1`);
     rngGen = new Math.seedrandom(`${seedInput.value}2`);
   }
-  create(game);
+  create();
   gameRun = true;
 }
 


### PR DESCRIPTION
When restarting there were times when the enemy hp message would remain on the screen on restart because currentEnemy was not changed to undefined. 