### PR TITLE
remove currentEnemy on restart

### DIFF
--- a/game.js
+++ b/game.js
@@ -349,6 +349,7 @@ function create(game) {
   };
   currentLvl = 1;
   currentWeapon = 0;
+  currentEnemy = undefined;
   init();
 
   renderText();


### PR DESCRIPTION
When the game restarted, there were times when the enemy hp message would remain on the screen. Now, on restart the enemy hp message should no longer appear. (Sorry for the multiple PR the first one was incorrectly formatted)